### PR TITLE
change: 使用技術をListで管理できるようにした #73 #74 #75

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -121,3 +121,16 @@ body {
     Helvetica, sans-serif;
   overscroll-behavior: none;
 }
+/* カルーセル用 */
+.embla {
+  overflow: hidden;
+}
+.embla__container {
+  display: flex;
+}
+.embla__slide {
+  flex-grow: 0;
+  flex-shrink: 0;
+  min-width: 0;
+  max-width: 100%;
+}

--- a/app/projects/[id]/page.tsx
+++ b/app/projects/[id]/page.tsx
@@ -6,6 +6,7 @@ import PageSteper from "@/components/projects/detail/PageSteper";
 import ProjectDetailContainer from "@/components/projects/detail/ProjectDetailContainer";
 import { client } from "@/libs/microcms";
 import { ProjectType } from "@/types/Project";
+import { parseTech } from "@/utils/cms/parseTech";
 
 async function getProject(id: string): Promise<ProjectType> {
   const data = await client.get({
@@ -13,9 +14,13 @@ async function getProject(id: string): Promise<ProjectType> {
     contentId: id,
   });
   return data;
-};
+}
 
-export default async function ProjectDetail({ params }: { params: { id: string } }) {
+export default async function ProjectDetail({
+  params,
+}: {
+  params: { id: string };
+}) {
   const id = params.id as string;
   const project = await getProject(id);
 
@@ -23,43 +28,42 @@ export default async function ProjectDetail({ params }: { params: { id: string }
 
   return (
     <>
-    <div>
-        <div id="homepage-background" className="fixed h-screen w-screen -z-1"></div>
-        <Script
-          src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r134/three.min.js"
-          strategy="beforeInteractive"
-        />
-        <Script
-          src="https://cdn.jsdelivr.net/npm/vanta@latest/dist/vanta.net.min.js"
-          strategy="beforeInteractive"
-        />
-        <Script id="script">
-          {`VANTA.NET({
-              el: "#homepage-background",
-              mouseControls: true,
-              touchControls: true,
-              gyroControls: false,
-              minHeight: 200.00,
-              minWidth: 200.00,
-              scale: 1.00,
-              scaleMobile: 1.00,
-              color: 0x69ff,
-              backgroundColor: 0x0
-            });`}
-        </Script>
-      </div>    
-      <main className="flex flex-col gap-20">
-        <PageSteper />
-        <section className="flex w-full justify-center items-center flex-col gap-12 px-4">
-          <div className="flex flex-col max-w-7xl gap-6">
-            <span className="text-2xl font-semibold palt">
-              天文同好会WAXA Webサイト制作
-            </span>
+      <main className="flex flex-col items-center">
+        <section className="w-full flex flex-col items-center">
+          <div className="w-full max-w-[1440px] flex flex-row items-stretch relative">
+            <div className="grow-[1] border-x border-x-(--pattern-fg) bg-[image:repeating-linear-gradient(315deg,_var(--pattern-fg)_0,_var(--pattern-fg)_1px,_transparent_0,_transparent_50%)] bg-[size:10px_10px] bg-fixed max-lg:hidden [--pattern-fg:var(--color-white)]/10"></div>
+            <div className="w-full max-w-7xl">
+              <div className="flex flex-col justify-center">
+                <section className="border-t border-b border-white/10 w-full max-w-7xl py-8">
+                  <h2 className="text-3xl lg:text-5xl font-light w-full divide-effect">
+                    <div className="pl-8">
+                      <PageSteper pageTitle={project.title} className="my-4" />
+                      <p className="[&>span]:inline-block">
+                        <span>{project.title}</span>
+                        <span className="font-mono text-sm opacity-60 px-1">
+                          {project.completeDate != null
+                            ? "Released"
+                            : "In development"}
+                          {" / "}
+                          {parseTech(project.technologies)[0].name}
+                        </span>
+                      </p>
+                    </div>
+                  </h2>
+                </section>
+              </div>
+            </div>
+            <div className="grow-[1] border-x border-x-(--pattern-fg) bg-[image:repeating-linear-gradient(315deg,_var(--pattern-fg)_0,_var(--pattern-fg)_1px,_transparent_0,_transparent_50%)] bg-[size:10px_10px] bg-fixed max-lg:hidden [--pattern-fg:var(--color-white)]/10"></div>
+          </div>
+        </section>
+        <section className="w-full flex flex-col items-center divide-effect">
+          <div className="w-full max-w-[1440px] flex flex-row items-stretch relative">
+            <div className="grow-[1] border-x border-x-(--pattern-fg) bg-[image:repeating-linear-gradient(315deg,_var(--pattern-fg)_0,_var(--pattern-fg)_1px,_transparent_0,_transparent_50%)] bg-[size:10px_10px] bg-fixed max-lg:hidden [--pattern-fg:var(--color-white)]/10"></div>
             <ProjectDetailContainer project={project} />
+            <div className="grow-[1] border-x border-x-(--pattern-fg) bg-[image:repeating-linear-gradient(315deg,_var(--pattern-fg)_0,_var(--pattern-fg)_1px,_transparent_0,_transparent_50%)] bg-[size:10px_10px] bg-fixed max-lg:hidden [--pattern-fg:var(--color-white)]/10"></div>
           </div>
         </section>
       </main>
-
     </>
   );
 }

--- a/components/projects/ProjectCard.tsx
+++ b/components/projects/ProjectCard.tsx
@@ -1,8 +1,13 @@
 import { ProjectType } from "@/types/Project";
 import Image from "next/image";
 import Link from "next/link";
+import { parseTech } from "@/utils/cms/parseTech";
 
 export const ProjectCard = ({ project, className }: { project: ProjectType, className?: string }) => {
+    const techs = parseTech(project.technologies);
+
+    console.log(techs);
+
   return (
     <Link href={`/projects/${project.id}`} className={className}>
       <article className="bg-foreground/10 border border-white/10 w-full @container p-2 h-full transition-all duration-300 **:transition-all **:duration-300">
@@ -21,6 +26,7 @@ export const ProjectCard = ({ project, className }: { project: ProjectType, clas
                 {" / "}
                 {/* project.technologies[0][1] */
                 /* これどういう仕様なんだ */}
+                {techs[0].name}
               </p>
               {project.title}
             </h3>

--- a/components/projects/ProjectCard.tsx
+++ b/components/projects/ProjectCard.tsx
@@ -24,8 +24,6 @@ export const ProjectCard = ({ project, className }: { project: ProjectType, clas
               <p className="font-mono text-sm opacity-60">
                 {project.completeDate != null ? "Released" : "In development"}
                 {" / "}
-                {/* project.technologies[0][1] */
-                /* これどういう仕様なんだ */}
                 {techs[0].name}
               </p>
               {project.title}

--- a/components/projects/detail/PageSteper.tsx
+++ b/components/projects/detail/PageSteper.tsx
@@ -1,19 +1,25 @@
 import Link from "next/link"
 
-export default function PageSteper() {
+export default function PageSteper({pageTitle,className }:{pageTitle:string,className?:string}) {
     return (
-        <div className="flex flex-col gap-2 mt-4 w-full max-w-xs ml-4 md:ml-8">
-            <div className="flex items-center gap-2">
-            <Link href="/" className="text-gray-500 hover:text-white transition-colors text-xs md:text-sm">
-                ホーム
-            </Link>
-            /
-            <Link href="/projects" className="text-gray-500 hover:text-white transition-colors text-xs md:text-sm">
-                プロジェクト一覧
-            </Link>
-            /
-          <span className="text-white text-xs md:text-sm">詳細</span>
+      <div className={className}>
+        <div className="flex items-center gap-2 text-xs md:text-sm">
+          <Link
+            href="/"
+            className="text-gray-500 hover:text-white transition-colors"
+          >
+            ホーム
+          </Link>
+          {">"}
+          <Link
+            href="/projects"
+            className="text-gray-500 hover:text-white transition-colors"
+          >
+            プロジェクト一覧
+          </Link>
+          {">"}
+          <span className="text-white text-xs md:text-sm">{pageTitle}</span>
         </div>
       </div>
-    )
+    );
 }

--- a/components/projects/detail/ProjectDetailContainer.tsx
+++ b/components/projects/detail/ProjectDetailContainer.tsx
@@ -1,27 +1,31 @@
-import Image from "next/image"
-import UsedTechnologySection from "./technology/UsedTechnologySection"
-import Overview from "./overview/Overview"
-import ContributorsSection from "./contributors/ContributorsSection"
+import UsedTechnologySection from "./technology/UsedTechnologySection";
+import Overview from "./overview/Overview";
+import ContributorsSection from "./contributors/ContributorsSection";
 import { ProjectType } from "@/types/Project";
+import { ImageCarousel } from "./carousel/carousel";
+import { CmsImageType } from "@/types/CmsImage";
 
 interface ProjectDetailContainerProps {
-    project: ProjectType;
+  project: ProjectType;
 }
 
-export default function ProjectDetailContainer({ project }: ProjectDetailContainerProps) {
-    return (
-        <div className="flex flex-col w-full max-w-lg justify-center">
-            {/* 画像 */}
-            <Image src={project.images[0].url ?? ""} alt={project.title} width={150} height={150} />
+export default function ProjectDetailContainer({
+  project,
+}: ProjectDetailContainerProps) {
+  return (
+    <div>
+      {/* 画像 */}
+      <ImageCarousel images={project.images} />
+      <div className="w-full max-w-7xl px-8">
+        {/* 概要 */}
+        <Overview project={project} />
 
-            {/* 概要 */}
-            <Overview project={project} />
+        {/* 使用技術 */}
+        <UsedTechnologySection project={project} />
 
-            {/* 使用技術 */}
-            <UsedTechnologySection project={project} />
-
-            {/* 貢献者 */}
-            <ContributorsSection project={project} />
-        </div>
-    )
+        {/* 貢献者 */}
+        <ContributorsSection project={project} />
+      </div>
+    </div>
+  );
 }

--- a/components/projects/detail/carousel/carousel.tsx
+++ b/components/projects/detail/carousel/carousel.tsx
@@ -1,0 +1,66 @@
+"use client";
+import React, { useCallback } from "react";
+import useEmblaCarousel from "embla-carousel-react";
+import { CmsImageType } from "@/types/CmsImage";
+import Image from "next/image";
+import { DotButton, useDotButton } from "./carouselDotButton";
+import { ChevronLeft, ChevronLeftCircle, ChevronRight, ChevronRightCircle } from "lucide-react";
+
+export function ImageCarousel({ images: images }: { images: CmsImageType[] }) {
+  const [emblaRef, emblaApi] = useEmblaCarousel({ loop: true });
+  const { selectedIndex, scrollSnaps, onDotButtonClick } =
+    useDotButton(emblaApi);
+  const scrollPrev = useCallback(() => {
+    if (emblaApi) emblaApi.scrollPrev();
+  }, [emblaApi]);
+
+  const scrollNext = useCallback(() => {
+    if (emblaApi) emblaApi.scrollNext();
+  }, [emblaApi]);
+
+  return (
+    <>
+      <div className="relative overflow-hidden mt-8 lg:mx-8">
+        <div className="absolute top-0 left-0 lg:w-[16%] h-[60vh] z-1 lg:bg-gradient-to-r from-background to-transparent"></div>
+        <div className="absolute top-0 right-0 lg:w-[16%] h-[60vh] z-1 lg:bg-gradient-to-l from-background to-transparent"></div>
+        <div className="embla bg-background" ref={emblaRef}>
+          <div className="embla__container">
+            {images.map((image: CmsImageType, index) => (
+              <div className="embla__slide flex basis-[90%] lg:basis-1/2 min-w-0 justify-center px-1 lg:px-3" key={index}>
+                <Image
+                  src={image.url}
+                  alt={`${index}枚目のスクリーンショット`}
+                  width={image.width}
+                  height={image.height}
+                  className="max-h-[60vh] w-auto rounded-2xl"
+                />
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      <div className="flex justify-between mx-4 py-4">
+        <div className="flex items-center">
+          <button className="embla__prev" onClick={scrollPrev}>
+            <ChevronLeft className="h-8 w-8 m-2 [&_path]:stroke-1 [&_path]:stroke-foreground/50 hover:cursor-pointer hover:[&_path]:stroke-foreground" />
+          </button>
+          <button className="embla__next" onClick={scrollNext}>
+            <ChevronRight className="h-8 w-8 m-2 [&_path]:stroke-1 [&_path]:stroke-foreground/50 hover:cursor-pointer hover:[&_path]:stroke-foreground" />
+          </button>
+        </div>
+        <div className="flex justify-end items-center gap-2 mx-4">
+          {scrollSnaps.map((_, index) => (
+            <DotButton
+              key={index}
+              onClick={() => onDotButtonClick(index)}
+              className={`${
+                index === selectedIndex ? "bg-foreground" : "bg-foreground/50"
+              } w-2 h-2 cursor-pointer rounded-xl`}
+            />
+          ))}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/components/projects/detail/carousel/carouselDotButton.tsx
+++ b/components/projects/detail/carousel/carouselDotButton.tsx
@@ -1,0 +1,62 @@
+import React, {
+  ComponentPropsWithRef,
+  useCallback,
+  useEffect,
+  useState,
+} from "react";
+import { EmblaCarouselType } from "embla-carousel";
+
+type UseDotButtonType = {
+  selectedIndex: number;
+  scrollSnaps: number[];
+  onDotButtonClick: (index: number) => void;
+};
+
+export const useDotButton = (
+  emblaApi: EmblaCarouselType | undefined
+): UseDotButtonType => {
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [scrollSnaps, setScrollSnaps] = useState<number[]>([]);
+
+  const onDotButtonClick = useCallback(
+    (index: number) => {
+      if (!emblaApi) return;
+      emblaApi.scrollTo(index);
+    },
+    [emblaApi]
+  );
+
+  const onInit = useCallback((emblaApi: EmblaCarouselType) => {
+    setScrollSnaps(emblaApi.scrollSnapList());
+  }, []);
+
+  const onSelect = useCallback((emblaApi: EmblaCarouselType) => {
+    setSelectedIndex(emblaApi.selectedScrollSnap());
+  }, []);
+
+  useEffect(() => {
+    if (!emblaApi) return;
+
+    onInit(emblaApi);
+    onSelect(emblaApi);
+    emblaApi.on("reInit", onInit).on("reInit", onSelect).on("select", onSelect);
+  }, [emblaApi, onInit, onSelect]);
+
+  return {
+    selectedIndex,
+    scrollSnaps,
+    onDotButtonClick,
+  };
+};
+
+type PropType = ComponentPropsWithRef<"button">;
+
+export const DotButton: React.FC<PropType> = (props) => {
+  const { children, ...restProps } = props;
+
+  return (
+    <button type="button" {...restProps}>
+      {children}
+    </button>
+  );
+};

--- a/components/projects/detail/contributors/ContributorsSection.tsx
+++ b/components/projects/detail/contributors/ContributorsSection.tsx
@@ -2,18 +2,23 @@ import ContributorCell from "./contributorCell";
 import { ProjectType } from "@/types/Project";
 
 interface ContributorsSectionProps {
-    project: ProjectType;
+  project: ProjectType;
 }
 
-export default function ContributorsSection({ project }: ContributorsSectionProps) {
-    return (
-        <div className="flex flex-col gap-2 items-start my-4">
-            <h2 className="font-bold text-xs palt">貢献者</h2>
-            <div className="w-full flex gap-6 justify-between grid grid-cols-1 md:grid-cols-2 lg:grid-cols-2">
-                {project.members.map((member) => (
-                    <ContributorCell key={member.id} member={member} />
-                ))}
-            </div>
-        </div>
-    )
+export default function ContributorsSection({
+  project,
+}: ContributorsSectionProps) {
+  return (
+    <div className="my-4">
+      <h2 className="font-extralight text-2xl palt lg:divide-effect">
+        <p className="font-mono text-sm opacity-60">Contributors</p>
+        貢献者
+      </h2>
+      <div className="w-full gap-6 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-2 py-4">
+        {project.members.map((member) => (
+          <ContributorCell key={member.id} member={member} />
+        ))}
+      </div>
+    </div>
+  );
 }

--- a/components/projects/detail/overview/Overview.tsx
+++ b/components/projects/detail/overview/Overview.tsx
@@ -6,9 +6,9 @@ interface OverviewProps {
 
 export default function Overview({ project }: OverviewProps) {
     return (
-        <div className="flex flex-col gap-2 items-start my-4">
+        <div className="flex flex-col gap-2 text-sm lg:text-base items-start my-8">
             {project.description.split("\n").map((text, index) => (
-                <p key={index} className="w-full text-xs palt">
+                <p key={index} className="w-full palt">
                     {text}
                 </p>
             ))}

--- a/components/projects/detail/technology/UsedTechnologySection.tsx
+++ b/components/projects/detail/technology/UsedTechnologySection.tsx
@@ -9,20 +9,28 @@ export default function UsedTechnologySection({ project }: UsedTechnologySection
     const techs = parseTech(project.technologies);
 
     return (
-        <div className="flex flex-col gap-2 items-start my-4">
-            <h2 className="font-bold text-xs palt">使用技術</h2>
-            <div className="flex gap-4 items-center">
-                {techs.map((tech, index) => (
-                    <a href={tech.url} target="_blank" rel="noopener noreferrer" key={index}>
-                        <Image 
-                            src={`/test-images/projects/tech/${tech.image}`} 
-                            alt={`[${tech.url}, ${tech.image}]`} 
-                            width={44} 
-                            height={44} 
-                        />
-                    </a>
-                ))}
-            </div>
+      <div className="my-4">
+        <h2 className="font-extralight text-2xl palt lg:divide-effect">
+          <p className="font-mono text-sm opacity-60">Technologies</p>
+          使用技術
+        </h2>
+        <div className="flex gap-4 items-center py-4">
+          {techs.map((tech, index) => (
+            <a
+              href={tech.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              key={index}
+            >
+              <Image
+                src={`/test-images/projects/tech/${tech.image}`}
+                alt={`[${tech.url}, ${tech.image}]`}
+                width={44}
+                height={44}
+              />
+            </a>
+          ))}
         </div>
-    )
+      </div>
+    );
 }

--- a/components/projects/detail/technology/UsedTechnologySection.tsx
+++ b/components/projects/detail/technology/UsedTechnologySection.tsx
@@ -1,45 +1,24 @@
 import Image from "next/image";
 import { ProjectType } from "@/types/Project";
-
+import { parseTech } from "@/utils/cms/parseTech";
 interface UsedTechnologySectionProps {
     project: ProjectType;
 }
 
 export default function UsedTechnologySection({ project }: UsedTechnologySectionProps) {
-    // プロジェクトから技術情報の文字列を取得して解析
-    const parseTechnologies = () => {
-        try {
-            // 文字列形式で返ってくる技術情報を配列に変換
-            if (project.technologies && typeof project.technologies === 'string') {
-                // 正規表現で [URL, filename] 形式の部分を抽出
-                const regex = /\["([^"]+)",\s*"([^"]+)"\]/g;
-                const techString = project.technologies as string;
-                const matches = [...techString.matchAll(regex)];
-                
-                return matches.map(match => [match[1], match[2]]);
-            }
-            
-            // すでに配列形式の場合はそのまま返す
-            return (project.technologies as any[]) || [];
-        } catch (error) {
-            console.error("技術情報の解析に失敗しました:", error);
-            return [];
-        }
-    };
-
-    const technologies = parseTechnologies();
+    const techs = parseTech(project.technologies);
 
     return (
         <div className="flex flex-col gap-2 items-start my-4">
             <h2 className="font-bold text-xs palt">使用技術</h2>
             <div className="flex gap-4 items-center">
-                {technologies.map(([url, imgName], index) => (
-                    <a href={url} target="_blank" rel="noopener noreferrer" key={index}>
+                {techs.map((tech, index) => (
+                    <a href={tech.url} target="_blank" rel="noopener noreferrer" key={index}>
                         <Image 
-                            src={`/test-images/projects/tech/${imgName}`} 
-                            alt={`[${url}, ${imgName}]`} 
-                            width={imgName === "js.png" || imgName === "wordpress.png" ? 44 : 50} 
-                            height={imgName === "js.png" || imgName === "wordpress.png" ? 44 : 50} 
+                            src={`/test-images/projects/tech/${tech.image}`} 
+                            alt={`[${tech.url}, ${tech.image}]`} 
+                            width={44} 
+                            height={44} 
                         />
                     </a>
                 ))}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@gsap/react": "^2.1.2",
+        "embla-carousel-react": "^8.6.0",
         "gsap": "^3.13.0",
         "lucide-react": "^0.508.0",
         "microcms-js-sdk": "^3.2.0",
@@ -2518,6 +2519,34 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/embla-carousel": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.6.0.tgz",
+      "integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==",
+      "license": "MIT"
+    },
+    "node_modules/embla-carousel-react": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/embla-carousel-react/-/embla-carousel-react-8.6.0.tgz",
+      "integrity": "sha512-0/PjqU7geVmo6F734pmPqpyHqiM99olvyecY7zdweCw+6tKEXnrE90pBiBbMMU8s5tICemzpQ3hi5EpxzGW+JA==",
+      "license": "MIT",
+      "dependencies": {
+        "embla-carousel": "8.6.0",
+        "embla-carousel-reactive-utils": "8.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.1 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/embla-carousel-reactive-utils": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/embla-carousel-reactive-utils/-/embla-carousel-reactive-utils-8.6.0.tgz",
+      "integrity": "sha512-fMVUDUEx0/uIEDM0Mz3dHznDhfX+znCCDCeIophYb1QGVM7YThSWX+wz11zlYwWFOr74b4QLGg0hrGPJeG2s4A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "embla-carousel": "8.6.0"
+      }
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@gsap/react": "^2.1.2",
+    "embla-carousel-react": "^8.6.0",
     "gsap": "^3.13.0",
     "lucide-react": "^0.508.0",
     "microcms-js-sdk": "^3.2.0",

--- a/types/Project.ts
+++ b/types/Project.ts
@@ -6,7 +6,13 @@ export interface ProjectType {
     title: string;
     description: string;
     images: CmsImageType[];
-    technologies: string[];
+    technologies: string;
     members: MemberType[];
     completeDate: Date;
   }
+
+export interface ParsedTechType {
+  name: string;
+  url: string;
+  image: string;
+}

--- a/utils/cms/parseTech.ts
+++ b/utils/cms/parseTech.ts
@@ -1,0 +1,5 @@
+import { ParsedTechType } from "@/types/Project";
+
+export const parseTech = (tech: string): ParsedTechType[] => {
+  return JSON.parse(tech);
+};


### PR DESCRIPTION
## CMSの変更内容
- 使用技術の保存形式を変更
  - 例
  `[
    {
      "name": "HTML",
      "url": "https://html.com/",
      "image": "html.png"
    },
   {
      "name": "HTML",
      "url": "https://html.com/",
      "image": "html.png"
    },
  ]`
- モックデータのいくつかのcompleteDateをnullに変更

## コードの変更内容
- parseTech.tsの作成
CMSの使用技術を配列で扱うためにparseする
- ProjectType.tsにParsedTechType（パース後の使用技術の型）の追加
- ProjectCard内に使用技術の1番目の技術名を表示
- Project詳細ページの表示方法の整理

## 動作確認
- Cardの確認
  - completeDateがnullの場合は**In development**そうでない場合は**Released**で表示された
  - 使用技術の1番目の技術名が表示された
-  詳細ページの確認
  - 使用技術が表示された